### PR TITLE
fixes related to crossover of session state

### DIFF
--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -9,20 +9,21 @@ from app.utils.sessions import get_session_id, get_session_id_ws
 #router = APIRouter(prefix="/chat", tags=["chat"])
 router = APIRouter()
 
+# # # TODO - Make this dependant on state
+# session_state = {}
 
-# # TODO - Make this dependant on state
-session_state = {}
+# # Initialize chat history
+# if "messages" not in session_state:
+#     session_state["messages"] = []
 
-# Initialize chat history
-if "messages" not in session_state:
-    session_state["messages"] = []
 
 
 @router.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
 
 
-    return await handle_websocket_chat(websocket, session_state)
+    #return await handle_websocket_chat(websocket, session_state)
+    return await handle_websocket_chat(websocket)
     # works
     # return await simple_ws_test(websocket)
 
@@ -36,7 +37,7 @@ async def clear_chat(request: Request):
 
     session_id = get_session_id(request)
     print("Clearing chat history for session: ", session_id)
-    session_state["messages"] = []
+    # session_state["messages"] = []
     clear_session_chat(request)
 
     content_chunk = """<div id="content">

--- a/app/utils/database/chat_utils.py
+++ b/app/utils/database/chat_utils.py
@@ -15,7 +15,7 @@ from psycopg import Connection
 
 @with_connection
 def get_latest_chats(conn:Connection, user: User) -> List[Chat]:
-    # get latest chat based on user ip
+    # get latest chat based on session id
     # return false if no chat exists
     session_id = user.session_id
     sql = f"""SELECT 
@@ -28,7 +28,8 @@ def get_latest_chats(conn:Connection, user: User) -> List[Chat]:
         timestamp
     FROM app.chats
         WHERE session_id = %s
-    ORDER BY timestamp DESC
+        AND chat_session_state = 1
+    ORDER BY chat_id ASC
     """
 
     cur = conn.cursor()


### PR DESCRIPTION
Fixing cross user session state - now messages are only show for a session state instead of user IP, since user ips could be the same if on campus.